### PR TITLE
strip hash chars from file path

### DIFF
--- a/lib/generateIcon.js
+++ b/lib/generateIcon.js
@@ -14,12 +14,12 @@ var svgo = new SVGO({
 function generatePng(siz, name, params) {
   return new Promise(function(resolve, reject) {
     var rsvgConvert;
-    var color = params.color;
+    var colorDir = params.color.replace('#', '');
     var svgCode = getIconSvg(params, siz);
-    var filename = pathModule.join(params.destFolder, color, 'png', siz.toString(), name + '.png');
+    var filename = pathModule.join(params.destFolder, colorDir, 'png', siz.toString(), name + '.png');
     rsvgConvert = spawn('rsvg-convert', ['-f', 'png', '-w', siz, '-o', filename]);
     if (process.env.INTERMEDIATE_SVG) {
-      fs.writeFileSync(pathModule.join(params.destFolder, color, 'png', siz.toString(), name + '.svg'), svgCode);
+      fs.writeFileSync(pathModule.join(params.destFolder, colorDir, 'png', siz.toString(), name + '.svg'), svgCode);
     }
     rsvgConvert.stdin.end(svgCode);
     rsvgConvert.once('error', reject);
@@ -38,14 +38,16 @@ function generatePng(siz, name, params) {
 
 
 function generatePngs(name, params) {
+  var colorDir = params.color.replace('#', '');
   return Promise.map(params.sizes, function (siz) {
-    mkdirp.sync(pathModule.join(params.destFolder, params.color, 'png', siz));
+    mkdirp.sync(pathModule.join(params.destFolder, colorDir, 'png', siz));
     return generatePng(siz, name, params);
   }, {concurrency: process.env['JOBS'] || 4});
 }
 
 function generateSvg(name, params) {
-  var svgFolder = pathModule.join(params.destFolder, params.color, 'svg');
+  var colorDir = params.color.replace('#', '');
+  var svgFolder = pathModule.join(params.destFolder, colorDir, 'svg');
   mkdirp.sync(svgFolder);
 
   return new Promise(function(resolve, reject) {


### PR DESCRIPTION
If a user specifies a color in hex format, the hash character (#) should
not appear in the file path. Otherwise this can cause numerous issues
with browsers and shell completion.
